### PR TITLE
Fix Ubuntu 14.04 IPv4 addresses in Vagrantfile

### DIFF
--- a/ubuntu14.4/Vagrantfile
+++ b/ubuntu14.4/Vagrantfile
@@ -28,52 +28,52 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # uncomment the line below to set up the ambari dev environment
     # u1401.vm.provision :shell, :path => "dev-bootstrap.sh"
     u1401.vm.hostname = "u1401.ambari.apache.org"
-    u1401.vm.network :private_network, ip: "192.168.76.101"
+    u1401.vm.network :private_network, ip: "192.168.14.101"
   end
 
   config.vm.define :u1402 do |u1402|
     u1402.vm.hostname = "u1402.ambari.apache.org"
-    u1402.vm.network :private_network, ip: "192.168.76.102"
+    u1402.vm.network :private_network, ip: "192.168.14.102"
   end
 
   config.vm.define :u1403 do |u1403|
     u1403.vm.hostname = "u1403.ambari.apache.org"
-    u1403.vm.network :private_network, ip: "192.168.76.103"
+    u1403.vm.network :private_network, ip: "192.168.14.103"
   end
 
   config.vm.define :u1404 do |u1404|
     u1404.vm.hostname = "u1404.ambari.apache.org"
-    u1404.vm.network :private_network, ip: "192.168.76.104"
+    u1404.vm.network :private_network, ip: "192.168.14.104"
   end
 
   config.vm.define :u1405 do |u1405|
     u1405.vm.hostname = "u1405.ambari.apache.org"
-    u1405.vm.network :private_network, ip: "192.168.76.105"
+    u1405.vm.network :private_network, ip: "192.168.14.105"
   end
 
   config.vm.define :u1406 do |u1406|
     u1406.vm.hostname = "u1406.ambari.apache.org"
-    u1406.vm.network :private_network, ip: "192.168.76.106"
+    u1406.vm.network :private_network, ip: "192.168.14.106"
   end
 
   config.vm.define :u1407 do |u1407|
     u1407.vm.hostname = "u1407.ambari.apache.org"
-    u1407.vm.network :private_network, ip: "192.168.76.107"
+    u1407.vm.network :private_network, ip: "192.168.14.107"
   end
 
   config.vm.define :u1408 do |u1408|
     u1408.vm.hostname = "u1408.ambari.apache.org"
-    u1408.vm.network :private_network, ip: "192.168.76.108"
+    u1408.vm.network :private_network, ip: "192.168.14.108"
   end
 
   config.vm.define :u1409 do |u1409|
     u1409.vm.hostname = "u1409.ambari.apache.org"
-    u1409.vm.network :private_network, ip: "192.168.76.109"
+    u1409.vm.network :private_network, ip: "192.168.14.109"
   end
 
   config.vm.define :u1410 do |u1410|
     u1410.vm.hostname = "u1410.ambari.apache.org"
-    u1410.vm.network :private_network, ip: "192.168.76.110"
+    u1410.vm.network :private_network, ip: "192.168.14.110"
   end
 
 end


### PR DESCRIPTION
Need to use 192.168.14.x prefix to comply with the IP configuration in the hosts files