### PR TITLE
fix vm box for Ubuntu12, old image url is broken

### DIFF
--- a/ubuntu12.4/Vagrantfile
+++ b/ubuntu12.4/Vagrantfile
@@ -7,16 +7,13 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # All Vagrant configuration is done here. The most common configuration
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "ubuntu12.4"
+  config.vm.box = "bento/ubuntu-12.04"
 
   # Fixes changes from https://github.com/mitchellh/vagrant/pull/4707
   config.ssh.insert_key = false
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-
-  # Ubuntu precise 64 VirtualBox
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", 3072] # RAM allocated to each VM


### PR DESCRIPTION
Error: 

```
vagrant up u1201
Bringing machine 'u1201' up with 'virtualbox' provider...
==> u1201: Box 'ubuntu12.4' could not be found. Attempting to find and install...
    u1201: Box Provider: virtualbox
    u1201: Box Version: >= 0
==> u1201: Box file was not detected as metadata. Adding it directly...
==> u1201: Adding box 'ubuntu12.4' (v0) for provider: virtualbox
    u1201: Downloading: http://files.vagrantup.com/precise64.box
    u1201: Download redirected to host: hashicorp-files.hashicorp.com
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

Failed to connect to hashicorp-files.hashicorp.com port 443: Operation timed out
```

Validate box url: 

```
wget -S --spider http://files.vagrantup.com/precise64.box
Spider mode enabled. Check if remote file exists.
--2018-05-23 11:58:27--  http://files.vagrantup.com/precise64.box
Resolving files.vagrantup.com (files.vagrantup.com)... 104.31.74.64, 104.31.75.64
Connecting to files.vagrantup.com (files.vagrantup.com)|104.31.74.64|:80... connected.
HTTP request sent, awaiting response...
  HTTP/1.1 405 Method Not Allowed
  Date: Wed, 23 May 2018 09:58:27 GMT
  Content-Type: text/plain; charset=utf-8
  Connection: keep-alive
  Set-Cookie: __cfduid=d7b855e0acf3506718170b87717ed0ec11527069507; expires=Thu, 23-May-19 09:58:27 GMT; path=/; domain=.vagrantup.com; HttpOnly
  Via: 1.1 vegur
  Server: cloudflare
  CF-RAY: 41f6aa0390ef2666-FRA
Remote file does not exist -- broken link!!!
```

After fix: 

```
vagrant up u1201
Bringing machine 'u1201' up with 'virtualbox' provider...
==> u1201: Box 'bento/ubuntu-12.04' could not be found. Attempting to find and install...
    u1201: Box Provider: virtualbox
    u1201: Box Version: >= 0
==> u1201: Loading metadata for box 'bento/ubuntu-12.04'
    u1201: URL: https://vagrantcloud.com/bento/ubuntu-12.04
==> u1201: Adding box 'bento/ubuntu-12.04' (v2.3.5) for provider: virtualbox
    u1201: Downloading: https://vagrantcloud.com/bento/boxes/ubuntu-12.04/versions/2.3.5/providers/virtualbox.box
==> u1201: Successfully added box 'bento/ubuntu-12.04' (v2.3.5) for 'virtualbox'!
==> u1201: Importing base box 'bento/ubuntu-12.04'...
==> u1201: Matching MAC address for NAT networking...
...
```